### PR TITLE
Fixed artifact package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.DS_Store
+/.vscode/

--- a/action.yml
+++ b/action.yml
@@ -137,8 +137,9 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         GITHUB_ACTOR: clearci
-
-      run: mvn -fn deploy --settings ./.mvn/settings.xml -T 4C -DskipTests --file pom.xml
+      run: |
+        git checkout v${{ steps.set-version.outputs.version }}
+        mvn -fn deploy --settings ./.mvn/settings.xml -T 4C -DskipTests --file pom.xml
       shell: bash
 
     - name: Upload artifacts 


### PR DESCRIPTION
Right now we are not checking out to specific tag branch, so it will push the packages with snapshot version.
https://github.com/ClearTax/clear-data-browser-be/packages/2225944

We have to checkout to the tag created and run the deploy command.